### PR TITLE
fix: reorder middleware to fix CORS headers not being sent

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,23 +13,13 @@ import routes from './routes';
 
 const app = express();
 
-// Security middleware
-app.use(helmet({
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'"],
-      scriptSrc: ["'self'"],
-      imgSrc: ["'self'", "data:", "https:"],
-    },
-  },
-}));
-
 // CORS configuration - strict environment separation
 const corsOptions: cors.CorsOptions = {
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+  exposedHeaders: ['X-Request-ID'],
+  optionsSuccessStatus: 204, // Some legacy browsers choke on 204
 };
 
 if (isDevelopment) {
@@ -41,6 +31,18 @@ if (isDevelopment) {
 }
 
 app.use(cors(corsOptions));
+
+// Security middleware (after CORS to avoid interference)
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      scriptSrc: ["'self'"],
+      imgSrc: ["'self'", "data:", "https:"],
+    },
+  },
+}));
 
 // Compression middleware
 app.use(compression());


### PR DESCRIPTION
## Bug Fix: CORS Headers Not Being Sent in Production

### Problem
The production backend was not sending CORS headers, causing the frontend to show 'Disconnected' status even though the backend was healthy. This was preventing the backend connection feature from working properly.

### Root Cause
The  middleware was applied before the CORS middleware, which was interfering with the CORS headers being sent in the response.

### Solution
1. **Reordered middleware**: Moved CORS middleware before helmet middleware to prevent interference
2. **Enhanced CORS config**: Added  and  for better browser compatibility
3. **Maintained security**: Helmet middleware still provides all security headers

### Testing
- ✅ Backend builds successfully
- ✅ Frontend builds successfully  
- ✅ CORS headers now properly sent (tested locally)
- ✅ OPTIONS preflight requests work correctly
- ✅ GET requests include proper CORS headers

### Related Issues
- Fixes the backend connection issue introduced in ticket #18
- Ensures the backend status component works correctly in production

### Files Changed
- : Reordered middleware and enhanced CORS configuration

### Verification
The fix has been tested locally and shows:
-  (dev) /  (prod)
- 
- 
- All security headers from helmet are still present

This fix will resolve the production backend connection issue once deployed to Railway.

### Related to
Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security and compatibility by updating the order of security and CORS middleware.
  * Enhanced CORS support for legacy browsers and exposed the `X-Request-ID` header for client access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->