### PR TITLE
HOTFIX: Fix middleware API calls for production authentication

### DIFF
--- a/src/app/api/users/[clerkUserId]/route.ts
+++ b/src/app/api/users/[clerkUserId]/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { UserRole } from '@/types/user';
 import { logger } from '@/lib/logger';
 import { VALID_USER_ROLES } from '@/lib/auth-utils';
+import { normalizeBackendUrl } from '@/lib/utils';
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3001';
+const BACKEND_URL = normalizeBackendUrl(process.env.BACKEND_URL || 'http://localhost:3001');
 
 // Bearer token validation regex - allows alphanumeric, dots, underscores, and hyphens
 const BEARER_TOKEN_REGEX = /^[a-zA-Z0-9._-]+$/;

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequest, validateUserRole } from '@/lib/auth-utils';
 import { logger } from '@/lib/logger';
+import { normalizeBackendUrl } from '@/lib/utils';
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3001';
+const BACKEND_URL = normalizeBackendUrl(process.env.BACKEND_URL || 'http://localhost:3001');
 
 // GET /api/users - Get all users (admin only)
 export async function GET(request: NextRequest): Promise<NextResponse> {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Normalize a backend URL by removing trailing slashes
+ * This prevents double slashes in API URLs when concatenating paths
+ * @param url - The backend URL to normalize
+ * @returns The normalized URL without trailing slashes
+ */
+export function normalizeBackendUrl(url: string): string {
+  return url.replace(/\/+$/, '')
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import { normalizeBackendUrl } from "@/lib/utils";
 
 // Define protected routes and their required roles
 const protectedRoutes = {
@@ -55,7 +56,7 @@ export default clerkMiddleware(async (auth, req) => {
     logger.info('Middleware: Root page access, checking user role for dashboard redirect');
     
     try {
-      const backendUrl = process.env.BACKEND_URL || 'http://localhost:3001';
+      const backendUrl = normalizeBackendUrl(process.env.BACKEND_URL || 'http://localhost:3001');
       const apiUrl = `${backendUrl}/api/users/${userId}`;
       logger.debug('Middleware: Making backend API call', { apiUrl });
       
@@ -104,7 +105,7 @@ export default clerkMiddleware(async (auth, req) => {
     
     try {
       // Fetch user role from backend API with retry logic
-      const backendUrl = process.env.BACKEND_URL || 'http://localhost:3001';
+      const backendUrl = normalizeBackendUrl(process.env.BACKEND_URL || 'http://localhost:3001');
       const apiUrl = `${backendUrl}/api/users/${userId}`;
       logger.debug('Middleware: Making backend API call', { apiUrl });
       

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -55,9 +55,9 @@ export default clerkMiddleware(async (auth, req) => {
     logger.info('Middleware: Root page access, checking user role for dashboard redirect');
     
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const apiUrl = `${baseUrl}/api/users/${userId}`;
-      logger.debug('Middleware: Making API call', { apiUrl });
+      const backendUrl = process.env.BACKEND_URL || 'http://localhost:3001';
+      const apiUrl = `${backendUrl}/api/users/${userId}`;
+      logger.debug('Middleware: Making backend API call', { apiUrl });
       
       const response = await fetch(apiUrl);
       logger.debug('Middleware: API Response received', { status: response.status, ok: response.ok });
@@ -103,10 +103,10 @@ export default clerkMiddleware(async (auth, req) => {
     logger.info('Middleware: Checking protected route', { pathname, userId });
     
     try {
-      // Fetch user role from API with retry logic
-      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const apiUrl = `${baseUrl}/api/users/${userId}`;
-      logger.debug('Middleware: Making API call', { apiUrl });
+      // Fetch user role from backend API with retry logic
+      const backendUrl = process.env.BACKEND_URL || 'http://localhost:3001';
+      const apiUrl = `${backendUrl}/api/users/${userId}`;
+      logger.debug('Middleware: Making backend API call', { apiUrl });
       
       let response;
       let retryCount = 0;


### PR DESCRIPTION
## 🚨 Critical Production Hotfix

### Problem
Authentication was failing in production with 500 errors on user API endpoints, causing infinite redirect loops and preventing users from accessing the application.

### Root Cause Analysis
The middleware was making API calls to `NEXT_PUBLIC_APP_URL` (defaulting to localhost:3000) instead of the backend service. This caused:
- Self-referential API calls in production
- 500 errors with empty error objects
- Middleware unable to fetch user roles
- Authentication failures and redirect loops

### Solution
- Changed middleware to call backend API directly using `BACKEND_URL`
- Eliminates circular frontend → frontend API → backend calls
- Uses direct frontend → backend calls for better performance
- Resolves localhost dependency in production

### Changes
- Updated two middleware API call locations to use `BACKEND_URL` instead of `NEXT_PUBLIC_APP_URL`
- Improved logging to distinguish backend API calls
- Maintains backward compatibility with localhost development

### Testing
- ✅ Build successful 
- ✅ TypeScript compilation passes
- ✅ No linting errors
- Ready for immediate deployment

### Impact
- Fixes critical authentication issues in production
- Eliminates need for additional environment variables
- Improves performance by removing unnecessary API hops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend connection settings to use a centralized backend URL.
  * Changed the default local backend port to 3001 for development.
  * Clarified log messages to explicitly reference backend API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->