### PR TITLE
HOTFIX: Fix user recreation after Supabase deletion

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -3,6 +3,7 @@ import { getSupabaseClient } from '../utils/supabase';
 import { logger } from '../utils/logger';
 import { 
   authenticateUser, 
+  authenticateClerkUser,
   requireRole, 
   requireUserAccess, 
   requireAdminForRoleChanges,
@@ -59,7 +60,7 @@ router.get('/',
 
 // POST /api/users - Create a new user
 router.post('/', 
-  authenticateUser,
+  authenticateClerkUser,
   async (req: AuthenticatedRequest, res: Response) => {
     try {
       const { email, role }: CreateUserRequest = req.body;


### PR DESCRIPTION
## 🚨 Critical Authentication Hotfix

### Problem
Users deleted from Supabase could not recreate their accounts, causing a 401 authentication error:
- User authenticates with Clerk ✅
- Reaches role-selection page ✅ 
- Tries to create account via POST /api/users ❌
- Backend requires user to exist in Supabase to authenticate ❌
- **Circular dependency**: Can't create user without authentication, can't authenticate without existing user

### Root Cause Analysis
```
Backend logs: "Authentication failed for user user_XXX: JSON object requested, multiple (or no) rows returned"
```

The `authenticateUser` middleware queries Supabase to validate users, but the user was deleted. This created an impossible situation where:
1. POST /api/users requires `authenticateUser` middleware
2. `authenticateUser` requires user to exist in Supabase
3. User doesn't exist in Supabase (was deleted)
4. **Result: 401 error, user cannot recreate account**

### Solution Implemented
✅ **New `authenticateClerkUser` middleware** for user creation:
- Validates Clerk user ID format (`user_XXXXX`)
- Does NOT require user to exist in Supabase
- Allows legitimate user recreation

✅ **Enhanced type system**:
- Added `pending` role for users during creation
- Updated `requireRole` middleware to handle pending users

✅ **Surgical change**:
- Only POST /api/users uses new middleware
- All other endpoints maintain existing security

### Security Maintained
- Still validates Clerk user ID format
- Still requires valid Authorization header
- Only affects user creation, not existing user operations
- Prevents unauthorized account creation

### Testing
- ✅ Backend builds successfully
- ✅ TypeScript compilation passes  
- ✅ No linting errors
- ✅ Maintains backward compatibility

### Impact
- **Fixes user recreation issue** for deleted Supabase users
- **Maintains security** through Clerk validation
- **No breaking changes** to existing functionality